### PR TITLE
deattach event emitter from client instance

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -86,15 +86,15 @@ export class PutioAPIClient {
   }
 
   public once(event: PutioAPIClientEventTypes, listener: EventListener) {
-    return eventEmitter.once(event, listener)
+    eventEmitter.once(event, listener)
   }
 
   public on(event: PutioAPIClientEventTypes, listener: EventListener) {
-    return eventEmitter.on(event, listener)
+    eventEmitter.on(event, listener)
   }
 
   public off(event: PutioAPIClientEventTypes, listener: EventListener) {
-    return eventEmitter.off(event, listener)
+    eventEmitter.off(event, listener)
   }
 
   public configure(options: IPutioAPIClientOptions) {

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -1,0 +1,12 @@
+import EventEmitter from 'event-emitter'
+
+export { EventListener } from 'event-emitter'
+
+export const EVENTS = {
+  ERROR: 'ERROR',
+  CLIENT_IP_CHANGED: 'CLIENT_IP_CHANGED',
+} as const
+
+export type PutioAPIClientEventTypes = typeof EVENTS[keyof typeof EVENTS]
+
+export const eventEmitter = EventEmitter()

--- a/src/middlewares/clientIPChangeEmitter.spec.ts
+++ b/src/middlewares/clientIPChangeEmitter.spec.ts
@@ -1,28 +1,24 @@
+import { eventEmitter, EVENTS } from '../eventEmitter'
 import {
-  MockPutioAPIClient,
   mockPutioAPIClientError,
   mockPutioAPIClientResponse,
 } from '../test-utils/mocks'
-import {
-  IPutioAPIClientError,
-  IPutioAPIClientMiddleware,
-  PutioAPIClientEventTypes,
-} from '../types'
-import create from './clientIPChangeEmitter'
+import { IPutioAPIClientError, PutioAPIClientMiddleware } from '../types'
+import { createClientIPChangeEmitterMiddleware } from './clientIPChangeEmitter'
 
 describe('middlewares/errorEmitter', () => {
-  const API = new MockPutioAPIClient()
-  let clientIPChangeEmitter: IPutioAPIClientMiddleware
+  const eventEmitterEmit = jest.spyOn(eventEmitter, 'emit')
+  let clientIPChangeEmitter: PutioAPIClientMiddleware
 
   beforeEach(() => {
     jest.resetAllMocks()
-    clientIPChangeEmitter = create(API)
+    clientIPChangeEmitter = createClientIPChangeEmitterMiddleware()
   })
 
   it('does not call client.emit method if the IP does not change', () => {
     clientIPChangeEmitter.onFulfilled(mockPutioAPIClientResponse)
     clientIPChangeEmitter.onFulfilled(mockPutioAPIClientResponse)
-    expect(API.emit).not.toHaveBeenCalled()
+    expect(eventEmitterEmit).not.toHaveBeenCalled()
   })
 
   it('does not call client.emit method if the IP changes from initial state', () => {
@@ -31,7 +27,7 @@ describe('middlewares/errorEmitter', () => {
       ...mockPutioAPIClientResponse,
       headers: { 'putio-client-ip': 1 },
     })
-    expect(API.emit).not.toHaveBeenCalled()
+    expect(eventEmitterEmit).not.toHaveBeenCalled()
   })
 
   it('calls client.emit method if the IP changes once', () => {
@@ -45,10 +41,10 @@ describe('middlewares/errorEmitter', () => {
       headers: { 'putio-client-ip': '198.168.0.2' },
     })
 
-    expect(API.emit).toBeCalledWith(
-      PutioAPIClientEventTypes.CLIENT_IP_CHANGED,
-      { IP: '198.168.0.1', newIP: '198.168.0.2' },
-    )
+    expect(eventEmitterEmit).toBeCalledWith(EVENTS.CLIENT_IP_CHANGED, {
+      IP: '198.168.0.1',
+      newIP: '198.168.0.2',
+    })
   })
 
   it('calls client.emit method if the IP changes multiple times', () => {
@@ -62,22 +58,22 @@ describe('middlewares/errorEmitter', () => {
       headers: { 'putio-client-ip': '198.168.0.2' },
     })
 
-    expect(API.emit).toBeCalledWith(
-      PutioAPIClientEventTypes.CLIENT_IP_CHANGED,
-      { IP: '198.168.0.1', newIP: '198.168.0.2' },
-    )
+    expect(eventEmitterEmit).toBeCalledWith(EVENTS.CLIENT_IP_CHANGED, {
+      IP: '198.168.0.1',
+      newIP: '198.168.0.2',
+    })
 
     clientIPChangeEmitter.onFulfilled({
       ...mockPutioAPIClientResponse,
       headers: { 'putio-client-ip': '198.168.0.1' },
     })
 
-    expect(API.emit).toBeCalledWith(
-      PutioAPIClientEventTypes.CLIENT_IP_CHANGED,
-      { IP: '198.168.0.2', newIP: '198.168.0.1' },
-    )
+    expect(eventEmitterEmit).toBeCalledWith(EVENTS.CLIENT_IP_CHANGED, {
+      IP: '198.168.0.2',
+      newIP: '198.168.0.1',
+    })
 
-    expect(API.emit).toBeCalledTimes(2)
+    expect(eventEmitterEmit).toBeCalledTimes(2)
   })
 
   it('calls client.emit method once if the IP changes to a falsy value', () => {
@@ -91,14 +87,14 @@ describe('middlewares/errorEmitter', () => {
       headers: { 'putio-client-ip': '198.168.0.2' },
     })
 
-    expect(API.emit).toBeCalledWith(
-      PutioAPIClientEventTypes.CLIENT_IP_CHANGED,
-      { IP: '198.168.0.1', newIP: '198.168.0.2' },
-    )
+    expect(eventEmitterEmit).toBeCalledWith(EVENTS.CLIENT_IP_CHANGED, {
+      IP: '198.168.0.1',
+      newIP: '198.168.0.2',
+    })
 
     clientIPChangeEmitter.onFulfilled(mockPutioAPIClientResponse)
 
-    expect(API.emit).toBeCalledTimes(1)
+    expect(eventEmitterEmit).toBeCalledTimes(1)
   })
 
   it('handles failed requests and updates the IP', () => {
@@ -124,10 +120,10 @@ describe('middlewares/errorEmitter', () => {
       headers: { 'putio-client-ip': '1.1.1.1' },
     })
 
-    expect(API.emit).toBeCalledWith(
-      PutioAPIClientEventTypes.CLIENT_IP_CHANGED,
-      { IP: '0.0.0.0', newIP: '1.1.1.1' },
-    )
+    expect(eventEmitterEmit).toBeCalledWith(EVENTS.CLIENT_IP_CHANGED, {
+      IP: '0.0.0.0',
+      newIP: '1.1.1.1',
+    })
   })
 
   it('does not call client.emit method if the error is not recognized', () => {
@@ -137,6 +133,6 @@ describe('middlewares/errorEmitter', () => {
       .onRejected(error as any)
       .catch(e => expect(e).toEqual(error))
 
-    expect(API.emit).not.toHaveBeenCalled()
+    expect(eventEmitterEmit).not.toHaveBeenCalled()
   })
 })

--- a/src/middlewares/clientIPChangeEmitter.ts
+++ b/src/middlewares/clientIPChangeEmitter.ts
@@ -1,15 +1,10 @@
 import { AxiosResponse } from 'axios'
-import { PutioAPIClient } from '../client'
-import {
-  IPutioAPIClientMiddlewareFactory,
-  PutioAPIClientEventTypes,
-} from '../types'
+import { PutioAPIClientMiddlewareFactory } from '../types'
+import { eventEmitter, EVENTS } from '../eventEmitter'
 
 const IP_HEADER_KEY = 'putio-client-ip'
 
-const createClientIPChangeEmitterMiddleware: IPutioAPIClientMiddlewareFactory = (
-  client: PutioAPIClient,
-) => {
+export const createClientIPChangeEmitterMiddleware: PutioAPIClientMiddlewareFactory = () => {
   let IP: string = ''
 
   const checkIP = (response: AxiosResponse) => {
@@ -21,7 +16,7 @@ const createClientIPChangeEmitterMiddleware: IPutioAPIClientMiddlewareFactory = 
     }
 
     if (newIP && IP !== newIP) {
-      client.emit(PutioAPIClientEventTypes.CLIENT_IP_CHANGED, { IP, newIP })
+      eventEmitter.emit(EVENTS.CLIENT_IP_CHANGED, { IP, newIP })
       IP = newIP
       return
     }
@@ -42,5 +37,3 @@ const createClientIPChangeEmitterMiddleware: IPutioAPIClientMiddlewareFactory = 
     },
   }
 }
-
-export default createClientIPChangeEmitterMiddleware

--- a/src/middlewares/errorEmitter.spec.ts
+++ b/src/middlewares/errorEmitter.spec.ts
@@ -1,21 +1,21 @@
+import { eventEmitter, EVENTS } from '../eventEmitter'
 import {
-  MockPutioAPIClient,
   mockPutioAPIClientError,
   mockPutioAPIClientResponse,
 } from '../test-utils/mocks'
-import { IPutioAPIClientError, PutioAPIClientEventTypes } from '../types'
-import create from './errorEmitter'
+import { IPutioAPIClientError } from '../types'
+import { createErrorEmitterMiddleware } from './errorEmitter'
 
 describe('middlewares/errorEmitter', () => {
-  const API = new MockPutioAPIClient()
-  const errorEmitter = create(API)
+  const eventEmitterEmit = jest.spyOn(eventEmitter, 'emit')
+  const errorEmitter = createErrorEmitterMiddleware()
 
   beforeEach(jest.resetAllMocks)
 
   describe('successful responses', () => {
     it('does not call client.emit method', () => {
       errorEmitter.onFulfilled(mockPutioAPIClientResponse)
-      expect(API.emit).not.toHaveBeenCalled()
+      expect(eventEmitterEmit).not.toHaveBeenCalled()
     })
   })
 
@@ -37,11 +37,7 @@ describe('middlewares/errorEmitter', () => {
       }
 
       errorEmitter.onRejected(error).catch(e => expect(e).toEqual(error))
-
-      expect(API.emit).toHaveBeenCalledWith(
-        PutioAPIClientEventTypes.ERROR,
-        error,
-      )
+      expect(eventEmitterEmit).toHaveBeenCalledWith(EVENTS.ERROR, error)
     })
   })
 })

--- a/src/middlewares/errorEmitter.ts
+++ b/src/middlewares/errorEmitter.ts
@@ -1,19 +1,12 @@
-import { PutioAPIClient } from '../client'
-import {
-  IPutioAPIClientMiddlewareFactory,
-  PutioAPIClientEventTypes,
-} from '../types'
+import { PutioAPIClientMiddlewareFactory } from '../types'
 import { identity } from '../utils'
+import { eventEmitter, EVENTS } from '../eventEmitter'
 
-const createErrorEmitterMiddleware: IPutioAPIClientMiddlewareFactory = (
-  client: PutioAPIClient,
-) => ({
+export const createErrorEmitterMiddleware: PutioAPIClientMiddlewareFactory = () => ({
   onFulfilled: identity,
 
   onRejected: error => {
-    client.emit(PutioAPIClientEventTypes.ERROR, error)
+    eventEmitter.emit(EVENTS.ERROR, error)
     return Promise.reject(error)
   },
 })
-
-export default createErrorEmitterMiddleware

--- a/src/middlewares/responseFormatter.spec.ts
+++ b/src/middlewares/responseFormatter.spec.ts
@@ -1,14 +1,12 @@
 import {
-  MockPutioAPIClient,
   mockPutioAPIClientError,
   mockPutioAPIClientResponse,
 } from '../test-utils/mocks'
 import { IPutioAPIClientError } from '../types'
-import create from './responseFormatter'
+import { createResponseFormatterMiddleware } from './responseFormatter'
 
 describe('middlewares/responseFormatter', () => {
-  const API = new MockPutioAPIClient()
-  const responseFormatter = create(API)
+  const responseFormatter = createResponseFormatterMiddleware()
 
   describe('successful responses', () => {
     it('transforms as expected', () => {

--- a/src/middlewares/responseFormatter.ts
+++ b/src/middlewares/responseFormatter.ts
@@ -1,10 +1,7 @@
-import {
-  IPutioAPIClientError,
-  IPutioAPIClientMiddlewareFactory,
-} from '../types'
+import { IPutioAPIClientError, PutioAPIClientMiddlewareFactory } from '../types'
 import { isPutioAPIErrorResponse } from '../utils'
 
-const createResponseFormatterMiddleware: IPutioAPIClientMiddlewareFactory = () => ({
+export const createResponseFormatterMiddleware: PutioAPIClientMiddlewareFactory = () => ({
   onFulfilled: response => ({
     ...response,
     body: response.data,
@@ -40,5 +37,3 @@ const createResponseFormatterMiddleware: IPutioAPIClientMiddlewareFactory = () =
     return Promise.reject(formattedError)
   },
 })
-
-export default createResponseFormatterMiddleware

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -1,17 +1,9 @@
 import { AxiosError } from 'axios'
-import { PutioAPIClient } from '../client'
 import {
   IPutioAPIClientError,
   IPutioAPIClientErrorData,
   IPutioAPIClientResponse,
 } from '../types'
-
-export class MockPutioAPIClient extends PutioAPIClient {
-  constructor() {
-    super({})
-    this.emit = jest.fn()
-  }
-}
 
 export const mockPutioAPIClientResponse: IPutioAPIClientResponse<{
   foo: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { AxiosError, AxiosResponse } from 'axios'
-import PutioAPIClient from '.'
 
 export interface IPutioAPIClientOptions {
   clientID?: number
@@ -26,21 +25,14 @@ export interface IPutioAPIClientError
   toJSON: () => IPutioAPIClientErrorData
 }
 
-export interface IPutioAPIClientMiddleware {
+export interface PutioAPIClientMiddleware {
   onFulfilled: (
     response: IPutioAPIClientResponse<any>,
   ) => IPutioAPIClientResponse<any>
   onRejected: (error: IPutioAPIClientError) => Promise<IPutioAPIClientError>
 }
 
-export type IPutioAPIClientMiddlewareFactory = (
-  client: PutioAPIClient,
-) => IPutioAPIClientMiddleware
-
-export enum PutioAPIClientEventTypes {
-  ERROR = 'ERROR',
-  CLIENT_IP_CHANGED = 'CLIENT_IP_CHANGED',
-}
+export type PutioAPIClientMiddlewareFactory = () => PutioAPIClientMiddleware
 
 export * from './resources/Events/types'
 export * from './resources/Files/types'


### PR DESCRIPTION
we don't really want to expose `emit` method through the client 👍 